### PR TITLE
refactor: create client receiver funcs and helpers

### DIFF
--- a/query.go
+++ b/query.go
@@ -1,0 +1,98 @@
+package sdk
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+
+	"connectrpc.com/connect"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/query"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/query/queryconnect"
+)
+
+type QueryServiceClient queryconnect.QueryServiceClient
+
+func NewQueryServiceClient(u *UtxorpcClient) QueryServiceClient {
+	return u.NewQueryServiceClient()
+}
+
+func (u *UtxorpcClient) NewQueryServiceClient() QueryServiceClient {
+	return queryconnect.NewQueryServiceClient(
+		u.httpClient,
+		u.baseUrl,
+		connect.WithGRPC(),
+	)
+}
+
+func (u *UtxorpcClient) QueryService() QueryServiceClient {
+	return u.Query
+}
+
+func (u *UtxorpcClient) ReadParams() (*connect.Response[query.ReadParamsResponse], error) {
+	ctx := context.Background()
+	return u.ReadParamsWithContext(ctx)
+}
+
+func (u *UtxorpcClient) ReadParamsWithContext(
+	ctx context.Context,
+) (*connect.Response[query.ReadParamsResponse], error) {
+	req := connect.NewRequest(&query.ReadParamsRequest{})
+	u.AddHeadersToRequest(req)
+	return u.Query.ReadParams(ctx, req)
+}
+
+func (u *UtxorpcClient) ReadUtxo(
+	txHashStr string,
+	txIndex uint32,
+) (*connect.Response[query.ReadUtxosResponse], error) {
+	var txHashBytes []byte
+	var err error
+	// Attempt to decode the input as hex
+	txHashBytes, hexErr := hex.DecodeString(txHashStr)
+	if hexErr != nil {
+		// If not hex, attempt to decode as Base64
+		txHashBytes, err = base64.StdEncoding.DecodeString(txHashStr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// Create TxoRef with the decoded hash bytes
+	txoRef := &query.TxoRef{
+		Hash:  txHashBytes, // Use the decoded []byte
+		Index: txIndex,
+	}
+	req := &query.ReadUtxosRequest{Keys: []*query.TxoRef{txoRef}}
+	return u.ReadUtxos(req)
+}
+
+func (u *UtxorpcClient) ReadUtxos(
+	req *query.ReadUtxosRequest,
+) (*connect.Response[query.ReadUtxosResponse], error) {
+	ctx := context.Background()
+	return u.ReadUtxosWithContext(ctx, req)
+}
+
+func (u *UtxorpcClient) ReadUtxosWithContext(
+	ctx context.Context,
+	queryReq *query.ReadUtxosRequest,
+) (*connect.Response[query.ReadUtxosResponse], error) {
+	req := connect.NewRequest(queryReq)
+	u.AddHeadersToRequest(req)
+	return u.Query.ReadUtxos(ctx, req)
+}
+
+func (u *UtxorpcClient) SearchUtxos(
+	req *query.SearchUtxosRequest,
+) (*connect.Response[query.SearchUtxosResponse], error) {
+	ctx := context.Background()
+	return u.SearchUtxosWithContext(ctx, req)
+}
+
+func (u *UtxorpcClient) SearchUtxosWithContext(
+	ctx context.Context,
+	queryReq *query.SearchUtxosRequest,
+) (*connect.Response[query.SearchUtxosResponse], error) {
+	req := connect.NewRequest(queryReq)
+	u.AddHeadersToRequest(req)
+	return u.Query.SearchUtxos(ctx, req)
+}

--- a/submit.go
+++ b/submit.go
@@ -1,0 +1,116 @@
+package sdk
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/submit/submitconnect"
+)
+
+type SubmitServiceClient submitconnect.SubmitServiceClient
+
+func (u *UtxorpcClient) NewSubmitServiceClient() SubmitServiceClient {
+	return submitconnect.NewSubmitServiceClient(
+		u.httpClient,
+		u.baseUrl,
+		connect.WithGRPC(),
+	)
+}
+
+func (u *UtxorpcClient) ReadMempool() (*connect.Response[submit.ReadMempoolResponse], error) {
+	ctx := context.Background()
+	return u.ReadMempoolWithContext(ctx)
+}
+
+func (u *UtxorpcClient) ReadMempoolWithContext(
+	ctx context.Context,
+) (*connect.Response[submit.ReadMempoolResponse], error) {
+	req := connect.NewRequest(&submit.ReadMempoolRequest{})
+	u.AddHeadersToRequest(req)
+	return u.Submit.ReadMempool(ctx, req)
+}
+
+func (u *UtxorpcClient) SubmitTx(
+	txCbor string,
+) (*connect.Response[submit.SubmitTxResponse], error) {
+	ctx := context.Background()
+	// Decode the transaction data from hex
+	txRawBytes, err := hex.DecodeString(txCbor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode transaction hash: %w", err)
+	}
+
+	// Create a SubmitTxRequest with the transaction data
+	tx := &submit.AnyChainTx{
+		Type: &submit.AnyChainTx_Raw{
+			Raw: txRawBytes,
+		},
+	}
+
+	// Create a list with one transaction
+	req := &submit.SubmitTxRequest{
+		Tx: []*submit.AnyChainTx{tx},
+	}
+	return u.SubmitTxWithContext(ctx, req)
+}
+
+func (u *UtxorpcClient) SubmitTxWithContext(
+	ctx context.Context,
+	txReq *submit.SubmitTxRequest,
+) (*connect.Response[submit.SubmitTxResponse], error) {
+	req := connect.NewRequest(txReq)
+	u.AddHeadersToRequest(req)
+	return u.Submit.SubmitTx(ctx, req)
+}
+
+func (u *UtxorpcClient) WaitForTx(
+	txRef string,
+) (*connect.ServerStreamForClient[submit.WaitForTxResponse], error) {
+	ctx := context.Background()
+	// Decode the transaction references from hex
+	var decodedRefs [][]byte
+	refBytes, err := hex.DecodeString(txRef)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to decode transaction reference %s: %w",
+			txRef,
+			err,
+		)
+	}
+	decodedRefs = append(decodedRefs, refBytes)
+
+	// Create a WaitForTxRequest with the decoded transaction references
+	req := &submit.WaitForTxRequest{
+		Ref: decodedRefs,
+	}
+	return u.WaitForTxWithContext(ctx, req)
+}
+
+func (u *UtxorpcClient) WaitForTxWithContext(
+	ctx context.Context,
+	txReq *submit.WaitForTxRequest,
+) (*connect.ServerStreamForClient[submit.WaitForTxResponse], error) {
+	req := connect.NewRequest(txReq)
+	u.AddHeadersToRequest(req)
+	return u.Submit.WaitForTx(ctx, req)
+}
+
+func (u *UtxorpcClient) WatchMempool() (
+	*connect.ServerStreamForClient[submit.WatchMempoolResponse],
+	error,
+) {
+	ctx := context.Background()
+	return u.WatchMempoolWithContext(ctx)
+}
+
+func (u *UtxorpcClient) WatchMempoolWithContext(ctx context.Context) (
+	*connect.ServerStreamForClient[submit.WatchMempoolResponse],
+	error,
+) {
+	req := connect.NewRequest(&submit.WatchMempoolRequest{})
+	u.AddHeadersToRequest(req)
+	return u.Submit.WatchMempool(ctx, req)
+}

--- a/sync.go
+++ b/sync.go
@@ -1,0 +1,82 @@
+package sdk
+
+import (
+	"context"
+	"encoding/hex"
+
+	"connectrpc.com/connect"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/sync"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/sync/syncconnect"
+)
+
+type SyncServiceClient syncconnect.SyncServiceClient
+
+func NewSyncServiceClient(u *UtxorpcClient) SyncServiceClient {
+	return u.NewSyncServiceClient()
+}
+
+func (u *UtxorpcClient) NewSyncServiceClient() SyncServiceClient {
+	return syncconnect.NewSyncServiceClient(
+		u.httpClient,
+		u.baseUrl,
+		connect.WithGRPC(),
+	)
+}
+
+func syncIntersect(blockHashStr string, blockIndex int64) []*sync.BlockRef {
+	var intersect []*sync.BlockRef
+	// Construct the BlockRef based on the provided parameters
+	blockRef := &sync.BlockRef{}
+	if blockHashStr != "" {
+		hash, err := hex.DecodeString(blockHashStr)
+		if err != nil {
+			return nil
+		}
+		blockRef.Hash = hash
+	}
+	// We assume blockIndex can be 0 or any positive number
+	if blockIndex > -1 {
+		blockRef.Index = uint64(blockIndex)
+	}
+	// Only add blockRef to intersect if at least one of blockHashStr or blockIndex is provided
+	if blockHashStr != "" || blockIndex > -1 {
+		intersect = []*sync.BlockRef{blockRef}
+	}
+	return intersect
+}
+
+func (u *UtxorpcClient) FetchBlock(
+	blockHashStr string,
+	blockIndex int64,
+) (*connect.Response[sync.FetchBlockResponse], error) {
+	ctx := context.Background()
+	req := &sync.FetchBlockRequest{Ref: syncIntersect(blockHashStr, blockIndex)}
+	return u.FetchBlockWithContext(ctx, req)
+}
+
+func (u *UtxorpcClient) FetchBlockWithContext(
+	ctx context.Context,
+	blockReq *sync.FetchBlockRequest,
+) (*connect.Response[sync.FetchBlockResponse], error) {
+	req := connect.NewRequest(blockReq)
+	u.AddHeadersToRequest(req)
+	return u.Sync.FetchBlock(ctx, req)
+}
+
+func (u *UtxorpcClient) FollowTip(
+	blockHashStr string,
+	blockIndex int64,
+) (*connect.ServerStreamForClient[sync.FollowTipResponse], error) {
+	ctx := context.Background()
+	req := &sync.FollowTipRequest{Intersect: syncIntersect(blockHashStr, blockIndex)}
+	return u.FollowTipWithContext(ctx, req)
+}
+
+func (u *UtxorpcClient) FollowTipWithContext(
+	ctx context.Context,
+	blockReq *sync.FollowTipRequest,
+) (*connect.ServerStreamForClient[sync.FollowTipResponse], error) {
+	req := connect.NewRequest(blockReq)
+	u.AddHeadersToRequest(req)
+	return u.Sync.FollowTip(ctx, req)
+}

--- a/watch.go
+++ b/watch.go
@@ -1,0 +1,64 @@
+package sdk
+
+import (
+	"context"
+	"encoding/hex"
+
+	"connectrpc.com/connect"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/watch"
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/watch/watchconnect"
+)
+
+type WatchServiceClient watchconnect.WatchServiceClient
+
+func NewWatchServiceClient(u *UtxorpcClient) WatchServiceClient {
+	return u.NewWatchServiceClient()
+}
+
+func (u *UtxorpcClient) NewWatchServiceClient() WatchServiceClient {
+	return watchconnect.NewWatchServiceClient(
+		u.httpClient,
+		u.baseUrl,
+		connect.WithGRPC(),
+	)
+}
+
+func watchIntersect(blockHashStr string, blockIndex int64) []*watch.BlockRef {
+	var intersect []*watch.BlockRef
+	// Construct the BlockRef based on the provided parameters
+	blockRef := &watch.BlockRef{}
+	if blockHashStr != "" {
+		hash, err := hex.DecodeString(blockHashStr)
+		if err != nil {
+			return nil
+		}
+		blockRef.Hash = hash
+	}
+	// We assume blockIndex can be 0 or any positive number
+	if blockIndex > -1 {
+		blockRef.Index = uint64(blockIndex)
+	}
+	// Only add blockRef to intersect if at least one of blockHashStr or blockIndex is provided
+	if blockHashStr != "" || blockIndex > -1 {
+		intersect = []*watch.BlockRef{blockRef}
+	}
+	return intersect
+}
+
+func (u *UtxorpcClient) WatchTx(
+	blockHashStr string,
+	blockIndex int64,
+) (*connect.ServerStreamForClient[watch.WatchTxResponse], error) {
+	ctx := context.Background()
+	req := &watch.WatchTxRequest{Intersect: watchIntersect(blockHashStr, blockIndex)}
+	return u.WatchTxWithContext(ctx, req)
+}
+
+func (u *UtxorpcClient) WatchTxWithContext(
+	ctx context.Context,
+	watchReq *watch.WatchTxRequest,
+) (*connect.ServerStreamForClient[watch.WatchTxResponse], error) {
+	req := connect.NewRequest(watchReq)
+	u.AddHeadersToRequest(req)
+	return u.Watch.WatchTx(ctx, req)
+}


### PR DESCRIPTION
Create helper functions at the top to reduce the amount of UTxORPC specific objects users will need to encounter.