### PR TITLE
ci: run pull proxy action on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: publish
 
 on:
   push:
+    branches: ['main']
     tags:
       - 'v*.*.*'
 
@@ -16,6 +17,7 @@ jobs:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
       - uses: actions/github-script@v7
         id: create-release
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           result-encoding: string


### PR DESCRIPTION
Allow running the workflow on merge to main and gate creating the release itself on git tag.